### PR TITLE
adding file size and file backup status options

### DIFF
--- a/SandboxBrowserExample/AppDelegate.swift
+++ b/SandboxBrowserExample/AppDelegate.swift
@@ -39,15 +39,39 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     
     public func enableSwipe() {
-        let pan = UISwipeGestureRecognizer(target: self, action: #selector(onSwipeDetected))
-        pan.numberOfTouchesRequired = 1
-        pan.direction = .left
-        UIApplication.shared.keyWindow?.addGestureRecognizer(pan)
+        let simpleBrowser = UISwipeGestureRecognizer(target: self, action: #selector(startSimpleBrowser))
+        simpleBrowser.numberOfTouchesRequired = 1
+        simpleBrowser.direction = .left
+        simpleBrowser.name = "swipe"
+        UIApplication.shared.keyWindow?.addGestureRecognizer(simpleBrowser)
+        let allOptionsBrowser = UISwipeGestureRecognizer(target: self, action: #selector(startAllOptionsBrowser))
+        allOptionsBrowser.numberOfTouchesRequired = 1
+        allOptionsBrowser.direction = .right
+        allOptionsBrowser.name = "swipe"
+        UIApplication.shared.keyWindow?.addGestureRecognizer(allOptionsBrowser)
+
     }
     
-    @objc func onSwipeDetected(){
-        
+    @objc func startSimpleBrowser(){
+        guard window?.rootViewController?.presentedViewController == nil else {
+            return // this means browser is already being presented
+        }
         let sandboxBrowser = SandboxBrowser()
+        presentSandboxBrowser(sandboxBrowser)
+    }
+
+    @objc func startAllOptionsBrowser(){
+        guard window?.rootViewController?.presentedViewController == nil else {
+            return // this means browser is already being presented
+        }
+        let sandboxBrowser = SandboxBrowser(
+            initialPath: URL(fileURLWithPath: NSHomeDirectory()),
+            options: SandboxBrowser.Options.allCases
+        )
+        presentSandboxBrowser(sandboxBrowser)
+    }
+
+    func presentSandboxBrowser(_ sandboxBrowser: SandboxBrowser) {
         sandboxBrowser.didSelectFile = { file, vc in
             print(file.name, file.type)
         }

--- a/SandboxBrowserExample/Base.lproj/Main.storyboard
+++ b/SandboxBrowserExample/Base.lproj/Main.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,6 +28,13 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="(or right)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bCW-11-kRR">
+                                <rect key="frame" x="149" y="377" width="77" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -39,6 +45,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="140" y="-2"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SandboxBrowserExample/SandboxBrowser/SandboxBrowser.swift
+++ b/SandboxBrowserExample/SandboxBrowser/SandboxBrowser.swift
@@ -21,7 +21,7 @@ public enum FileType: String {
     case file = "file"
     case sqlite = "sqlite"
     case log = "log"
-    
+
     var fileName: String {
         switch self {
         case .directory: return "directory"
@@ -34,11 +34,18 @@ public enum FileType: String {
     }
 }
 
+public enum BackupStatus: String {
+    case excluded = "🔘"
+    case included = "🔵"
+    case failure = "🟠"
+    case unknown = "🟡"
+}
+
 public struct FileItem {
     public var name: String
     public var path: String
     public var type: FileType
-    
+
     public var modificationDate: Date {
         do {
             let attr = try FileManager.default.attributesOfItem(atPath: path)
@@ -48,43 +55,112 @@ public struct FileItem {
             return Date()
         }
     }
-    
+
     var image: UIImage {
         let bundle = Bundle(for: FileListViewController.self)
         let path = bundle.path(forResource: "Resources", ofType: "bundle")
         let resBundle = Bundle(path: path!)!
-        
+
         return UIImage(contentsOfFile: resBundle.path(forResource: type.fileName, ofType: "png")!)!
+    }
+
+    var backupStatus: BackupStatus {
+
+        let fileURL = URL(fileURLWithPath: path)
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            if let isExcludedFromBackup = resourceValues.isExcludedFromBackup {
+                return isExcludedFromBackup ? .excluded : .included
+            }
+        } catch {
+            return .failure
+        }
+        return .unknown // Default to true if unable to retrieve the attribute
+    }
+
+    func markFileAsExcludedFromBackup(excluded: Bool) -> Bool {
+            // try marking file and return false if somethin went wrong
+        var fileURL = URL(fileURLWithPath: path)
+        do {
+            var resourceValues = try fileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            resourceValues.isExcludedFromBackup = excluded
+            try fileURL.setResourceValues(resourceValues)
+        } catch {
+            return false
+        }
+        return true
+    }
+
+    var size: Int64? {
+        do {
+            let fileAttributes = try FileManager.default.attributesOfItem(atPath: path)
+            if let fileSize = fileAttributes[FileAttributeKey.size] as? NSNumber {
+                return fileSize.int64Value
+            } else {
+                print("Failed to get file size attribute.")
+                return nil
+            }
+        } catch {
+            print("Failed to get file attributes for path: \(path). Error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    var sizeString: String {
+        if let sizeBytes = size {
+            return ByteCountFormatter().string(for: sizeBytes) ?? "error"
+        } else {
+            return "N/A"
+        }
     }
 }
 
+
+
 public class SandboxBrowser: UINavigationController {
-    
+
+    public enum Options: CaseIterable {
+        /// simple file iCloud backup status preview
+        /// you able to see if files are set for backup
+        /// and able to edit backup status (this to ensure thing is working on _this_ phone/setup)
+        case backupDisplay
+        /// in case it is enabled possible a bit slowdown
+        /// you will see file size next to date
+        case fileSizeDisplay
+    }
+
+    private(set) public var options: [SandboxBrowser.Options]!
+
     var fileListVC: FileListViewController?
-    
+
+
     open var didSelectFile: ((FileItem, FileListViewController) -> ())? {
         didSet {
             fileListVC?.didSelectFile = didSelectFile
         }
     }
-    
+
     public convenience init() {
-        self.init(initialPath: URL(fileURLWithPath: NSHomeDirectory()))
+        self.init(initialPath: URL(fileURLWithPath: NSHomeDirectory()), options: [])
     }
-    
-    public convenience init(initialPath: URL) {
-        let fileListVC = FileListViewController(initialPath: initialPath)
+
+    public convenience init(initialPath: URL, options: [Options]) {
+        let fileListVC = FileListViewController(
+            initialPath: initialPath,
+            options: options
+        )
         self.init(rootViewController: fileListVC)
         self.fileListVC = fileListVC
+        self.options = options
     }
 }
 
 public class FileListViewController: UIViewController {
-    
+
     private struct Misc {
         static let cellIdentifier = "FileCell"
     }
-    
+
     private lazy var tableView: UITableView = {
         let view = UITableView(frame: self.view.bounds)
         view.backgroundColor = .white
@@ -97,82 +173,101 @@ public class FileListViewController: UIViewController {
         view.addGestureRecognizer(longPress)
         return view
     }()
-    
+
     private var items: [FileItem] = [] {
         didSet {
             tableView.reloadData()
         }
     }
-    
+
     public var didSelectFile: ((FileItem, FileListViewController) -> ())?
     private var initialPath: URL?
-    
-    public convenience init(initialPath: URL) {
+    private var options: [SandboxBrowser.Options]!
+
+    public convenience init(initialPath: URL, options: [SandboxBrowser.Options]) {
         self.init()
-        
+
         self.initialPath = initialPath
+        self.options = options
         self.title = initialPath.lastPathComponent
     }
-    
+
     override public func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = .white
         view.addSubview(tableView)
-        
+
         loadPath(initialPath!.relativePath)
         navigationItem.rightBarButtonItem = .init(barButtonSystemItem: .stop, target: self, action: #selector(close))
+
+        let refreshControl = UIRefreshControl()
+        refreshControl.attributedTitle = NSAttributedString(string: "R E L O A D")
+        refreshControl.addTarget(self, action: #selector(self.refresh(_:)), for: .valueChanged)
+        tableView.addSubview(refreshControl)
+        tableView.refreshControl = refreshControl
     }
-    
+
     @objc private func onLongPress(gesture: UILongPressGestureRecognizer) {
-        
+
         let point = gesture.location(in: tableView)
         guard let indexPath = tableView.indexPathForRow(at: point) else { return }
         let item = items[indexPath.row]
         if item.type != .directory { shareFile(item.path) }
     }
-    
+
     @objc private func close() {
         dismiss(animated: true, completion: nil)
     }
-    
+
+    @objc func refresh(_ sender: AnyObject) {
+        DispatchQueue.main.async {
+            self.loadPath(self.initialPath!.relativePath)
+            self.tableView.refreshControl?.endRefreshing()
+        }
+    }
+
     private func loadPath(_ path: String = "") {
-        
+
         guard let paths = try? FileManager.default.contentsOfDirectory(atPath: path) else {
           return
         }
-        
+
         var filelist: [FileItem] = []
         paths
             .filter { !$0.hasPrefix(".") }
             .forEach { subpath in
             var isDir: ObjCBool = ObjCBool(false)
-            
+
             let fullpath = path.appending("/" + subpath)
+
             FileManager.default.fileExists(atPath: fullpath, isDirectory: &isDir)
-            
+
             var pathExtension = URL(fileURLWithPath: fullpath).pathExtension.lowercased()
             if pathExtension.hasPrefix("sqlite") || pathExtension == "db" { pathExtension = "sqlite" }
-            
+
             let filetype: FileType = isDir.boolValue ? .directory : FileType(rawValue: pathExtension) ?? .file
             let fileItem = FileItem(name: subpath, path: fullpath, type: filetype)
             filelist.append(fileItem)
         }
-        items = filelist
+        DispatchQueue.main.async {
+            self.items = filelist
+        }
+
     }
-    
+
     private func shareFile(_ filePath: String) {
-        
+
         let controller = UIActivityViewController(
             activityItems: [NSURL(fileURLWithPath: filePath)],
             applicationActivities: nil)
-        
+
         controller.excludedActivityTypes = [
             .postToTwitter, .postToFacebook, .postToTencentWeibo, .postToWeibo,
             .postToFlickr, .postToVimeo, .message, .addToReadingList,
             .print, .copyToPasteboard, .assignToContact, .saveToCameraRoll,
         ]
-        
+
         if UIDevice.current.userInterfaceIdiom == .pad {
             controller.popoverPresentationController?.sourceView = view
             controller.popoverPresentationController?.sourceRect = CGRect(x: UIScreen.main.bounds.size.width * 0.5, y: UIScreen.main.bounds.size.height * 0.5, width: 10, height: 10)
@@ -188,18 +283,18 @@ public class FileListViewController: UIViewController {
 final class FileCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         var imageFrame = imageView!.frame
         imageFrame.size.width = 42
         imageFrame.size.height = 42
         imageView?.frame = imageFrame
         imageView?.center.y = contentView.center.y
-        
+
         var textLabelFrame = textLabel!.frame
         textLabelFrame.origin.x = imageFrame.maxX + 10
         textLabelFrame.origin.y = textLabelFrame.origin.y - 3
         textLabel?.frame = textLabelFrame
-        
+
         var detailLabelFrame = detailTextLabel!.frame
         detailLabelFrame.origin.x = textLabelFrame.origin.x
         detailLabelFrame.origin.y = detailLabelFrame.origin.y + 3
@@ -211,17 +306,28 @@ extension FileListViewController: UITableViewDelegate, UITableViewDataSource {
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return items.count
     }
-    
+
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell = tableView.dequeueReusableCell(withIdentifier: Misc.cellIdentifier)
         if cell == nil { cell = FileCell(style: .subtitle, reuseIdentifier: Misc.cellIdentifier) }
-        
+
         let item = items[indexPath.row]
-        cell?.textLabel?.text = item.name
+        if options.contains(.backupDisplay) {
+            cell?.textLabel?.text = item.backupStatus.rawValue + item.name
+        } else {
+            cell?.textLabel?.text = item.name
+        }
+
         cell?.imageView?.image = item.image
-        cell?.detailTextLabel?.text = DateFormatter.localizedString(from: item.modificationDate,
-                                                                    dateStyle: .medium,
-                                                                    timeStyle: .medium)
+        var detailText = DateFormatter.localizedString(from: item.modificationDate,
+                                                       dateStyle: .medium,
+                                                       timeStyle: .medium)
+        if options.contains(.fileSizeDisplay) {
+            detailText += " | " + item.sizeString
+        }
+
+        cell?.detailTextLabel?.text = detailText
+
         if #available(iOS 13.0, *) {
             cell?.detailTextLabel?.textColor = .secondaryLabel
         } else {
@@ -230,21 +336,45 @@ extension FileListViewController: UITableViewDelegate, UITableViewDataSource {
         cell?.accessoryType = item.type == .directory ? .disclosureIndicator : .none
         return cell!
     }
-    
+
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard indexPath.row < items.count else { return }
-        
+
         tableView.deselectRow(at: indexPath, animated: true)
-        
+
         let item = items[indexPath.row]
-        
+
         switch item.type {
         case .directory:
-            let sandbox = FileListViewController(initialPath: URL(fileURLWithPath: item.path))
+            let sandbox = FileListViewController(
+                initialPath: URL(fileURLWithPath: item.path),
+                options: options
+            )
             sandbox.didSelectFile = didSelectFile
             self.navigationController?.pushViewController(sandbox, animated: true)
         default:
             didSelectFile?(item, self)
         }
+    }
+
+    public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard options.contains(.backupDisplay) else { return nil }
+        let item = self.items[indexPath.row]
+        let itemIsExcluded = item.backupStatus != .included
+        let title = itemIsExcluded ? "Add to Backup" : "Exclude from Backup"
+        let contextItem = UIContextualAction(style: .normal, title: title) {  (contextualAction, view, completion) in
+            if item.markFileAsExcludedFromBackup(excluded: !itemIsExcluded) == false {
+                UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+            } else {
+                UISelectionFeedbackGenerator().selectionChanged()
+            }
+            DispatchQueue.main.async {
+                self.tableView.reloadRows(at: [indexPath], with: .automatic)
+            }
+            completion(true)
+        }
+        let swipeActions = UISwipeActionsConfiguration(actions: [contextItem])
+
+        return swipeActions
     }
 }

--- a/SandboxBrowserExample/SandboxBrowser/SandboxBrowser.swift
+++ b/SandboxBrowserExample/SandboxBrowser/SandboxBrowser.swift
@@ -35,10 +35,10 @@ public enum FileType: String {
 }
 
 public enum BackupStatus: String {
-    case excluded = "🔘"
-    case included = "🔵"
-    case failure = "🟠"
-    case unknown = "🟡"
+    case excluded = "∅"
+    case included = "✪"
+    case failure = "⧮"
+    case unknown = "⍰"
 }
 
 public struct FileItem {
@@ -312,11 +312,7 @@ extension FileListViewController: UITableViewDelegate, UITableViewDataSource {
         if cell == nil { cell = FileCell(style: .subtitle, reuseIdentifier: Misc.cellIdentifier) }
 
         let item = items[indexPath.row]
-        if options.contains(.backupDisplay) {
-            cell?.textLabel?.text = item.backupStatus.rawValue + item.name
-        } else {
-            cell?.textLabel?.text = item.name
-        }
+        cell?.textLabel?.text = item.name
 
         cell?.imageView?.image = item.image
         var detailText = DateFormatter.localizedString(from: item.modificationDate,
@@ -324,6 +320,10 @@ extension FileListViewController: UITableViewDelegate, UITableViewDataSource {
                                                        timeStyle: .medium)
         if options.contains(.fileSizeDisplay) {
             detailText += " | " + item.sizeString
+        }
+
+        if options.contains(.backupDisplay) {
+            detailText = item.backupStatus.rawValue + "\u{2009}" + detailText
         }
 
         cell?.detailTextLabel?.text = detailText


### PR DESCRIPTION
Hi! 👋 

I've added options to provide a bit more context to the view – maybe you'll like it.

Added:  

 ### SandboxBrowser.Options
- `backupDisplay` : to display files marked (or not marked) for a backup (unencrypted backup or iCloud)
- `fileSizeDisplay` : provides display of the file size

 ### refreshControl
yep, pull to refresh functionality, might be useful for not 'rebooting' the SandboxBrowser when your system writes something actively

_options are optional_ : means, by default SandboxBrowser stays and operates "as is"

![sample](https://github.com/user-attachments/assets/b0439cfc-fd88-4c50-a7bd-5f11e8af67a9)
